### PR TITLE
Update clang-version 16 from 16.0.0 to 16.0.3

### DIFF
--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -43,7 +43,7 @@ jobs:
           - clang-version: 15
             release: llvm-project-15.0.2.src
           - clang-version: 16
-            release: llvm-project-16.0.0.src
+            release: llvm-project-16.0.3.src
           - os: linux
             runner: ubuntu-20.04
             os-cmake-args: '-DLLVM_BUILD_STATIC=ON -DCMAKE_CXX_FLAGS="-s -flto" ${POSIX_CMAKE_ARGS}'


### PR DESCRIPTION
There are some regressions in clang-format 16.0.0 that are causing issues (in particular llvm/llvm-project#62161 fixed in llvm/llvm-project-release-prs#421) so it would be great if a later version of LLVM v16 could be used. This PR updates it to the latest version (16.0.3).