### PR TITLE
add clang 13.0.1

### DIFF
--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -38,6 +38,8 @@ jobs:
             release: llvm-project-12.0.1.src
           - clang-version: 13
             release: llvm-project-13.0.0.src
+          - clang-version: 13.0.1
+            release: llvm-project-13.0.1.src
           - clang-version: 14
             release: llvm-project-14.0.0.src
           - clang-version: 15


### PR DESCRIPTION
13.0.1 has a subtle difference with 13.0.0 when formatting ObjC enums.

13:
```objc
enum crop_mode
{
     CROP_NONE,
     CROP_MANUAL,
     CROP_TO_WINDOW,
```
13.0.1:
```objc
enum crop_mode {
     CROP_NONE,
     CROP_MANUAL,
     CROP_TO_WINDOW,
```