### PR TITLE
add clang-apply-replacements to the managed tools

### DIFF
--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -146,7 +146,7 @@ jobs:
     - name: cmake
       run: cmake -S ${{ matrix.release }}/llvm -B ${{ matrix.release }}/build ${{ env.COMMON_CMAKE_ARGS }} ${{ matrix.os-cmake-args }} ${{ matrix.extra-cmake-args }}
     - name: build
-      run: cmake --build ${{ matrix.release }}/build ${{ matrix.build-args }} --target clang-format clang-query clang-tidy
+      run: cmake --build ${{ matrix.release }}/build ${{ matrix.build-args }} --target clang-format clang-query clang-tidy clang-apply-replacements
     - name: print dependencies
       if: ${{ matrix.os == 'macosx' }}
       run: otool -L ${{ matrix.release }}/build/bin/clang-format
@@ -156,6 +156,7 @@ jobs:
         mv clang-format${{ matrix.dotexe }} clang-format-${{ env.suffix }}${{ matrix.dotexe }}
         mv clang-query${{ matrix.dotexe }} clang-query-${{ env.suffix }}${{ matrix.dotexe }}
         mv clang-tidy${{ matrix.dotexe }} clang-tidy-${{ env.suffix }}${{ matrix.dotexe }}
+        mv clang-apply-replacements${{ matrix.dotexe }} clang-apply-replacements-${{ env.suffix }}${{ matrix.dotexe }}
     - name: create and print sha512sum
       shell: bash
       run: |
@@ -163,10 +164,12 @@ jobs:
         ${{ matrix.shacmd }} clang-format-${{ env.suffix }} > clang-format-${{ env.suffix }}.sha512sum
         ${{ matrix.shacmd }} clang-query-${{ env.suffix }} > clang-query-${{ env.suffix }}.sha512sum
         ${{ matrix.shacmd }} clang-tidy-${{ env.suffix }} > clang-tidy-${{ env.suffix }}.sha512sum
+        ${{ matrix.shacmd }} clang-apply-replacements-${{ env.suffix }} > clang-apply-replacements-${{ env.suffix }}.sha512sum
         echo "Checksums are: "
         cat clang-format-${{ env.suffix }}.sha512sum
         cat clang-query-${{ env.suffix }}.sha512sum
         cat clang-tidy-${{ env.suffix }}.sha512sum
+        cat clang-apply-replacements-${{ env.suffix }}.sha512sum
     - name: upload artifacts
       uses: actions/upload-artifact@v2
       with:


### PR DESCRIPTION
I have a workflow that needs a two-step approach to applying suggested fixes by clang-tidy.
Which means I need the `clang-apply-replacements` binary to apply the suggestions recorded by clang-tidy.
I have only tested this for clang-17 as of yet. Please let me know if you'd generally accept this PR and I'd run the whole suite in my fork too.