### PR TITLE
Fix LLVM 20 build

### DIFF
--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -51,7 +51,7 @@ jobs:
           - clang-version: 19
             release: llvm-project-19.1.0.src
           - clang-version: 20
-            release: llvm-project-20.0.0.src
+            release: llvm-project-20.1.0.src
           - os: linux
             runner: ubuntu-20.04
             os-cmake-args: '-DLLVM_BUILD_STATIC=ON -DCMAKE_CXX_FLAGS="-s -flto" ${POSIX_CMAKE_ARGS} ${LINUX_CMAKE_ARGS}'


### PR DESCRIPTION
Hi! I've noticed that the CI is failing on LLVM 20 build.

LLVM had recently changed its versioning convention, so there will no longer be any x.0.y versions - public releases start at x.1.0

This changes version from 20.0.0 to 20.1.0 that matches the official release on their GitHub page
https://github.com/llvm/llvm-project/releases/tag/llvmorg-20.1.0

I've ran the pipeline for LLVM 20 with these fixes on my fork, builds ok
https://github.com/bgs99/clang-tools-static-binaries/actions/runs/13893312126
