### PR TITLE
Smaller macos artifacts

### DIFF
--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -2,7 +2,7 @@ name: clang-tools-static-amd64
 
 on:
   push:
-    branches: [ master]
+    branches: [ master, smaller-artifacts ]
 
 jobs:
   build:

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -79,7 +79,8 @@ jobs:
     env:
       COMMON_CMAKE_ARGS: '-DBUILD_SHARED_LIBS=OFF -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra"'
       LINUX_CMAKE_ARGS: '-DCMAKE_CXX_COMPILER=g++-10 -DCMAKE_C_COMPILER=gcc-10'
-      MACOS_CMAKE_ARGS: '-DCMAKE_CXX_COMPILER=g++-14 -DCMAKE_C_COMPILER=gcc-14'
+      # Additional macos flags reduce file sizes
+      MACOS_CMAKE_ARGS: '-DCMAKE_CXX_COMPILER=g++-14 -DCMAKE_C_COMPILER=gcc-14 -DLLVM_ENABLE_ASSERTIONS=OFF -DLLVM_LINK_LLVM_DYLIB=ON -DLLVM_BUILD_LLVM_DYLIB=ON'
       POSIX_CMAKE_ARGS: '-DCMAKE_BUILD_TYPE=MinSizeRel'
       RELEASE: '${{ matrix.release }}'
       suffix: '${{ matrix.clang-version }}_${{ matrix.os }}-amd64'


### PR DESCRIPTION
Attempts to reduce the size of macos artifacts

Archiving logs from here:

https://github.com/muttleyxd/clang-tools-static-binaries/actions/runs/14106644358/job/39537574961

```
./clang-tools-llvm-project-19.1.0.src-19_linux-amd64:
total 102628
drwxr-xr-x  2 runner docker     4096 Mar 27 17:51 .
drwxr-xr-x 59 runner docker     4096 Mar 27 17:51 ..
-rw-r--r--  1 runner docker  3559952 Mar 27 17:51 clang-apply-replacements-19_linux-amd64
-rw-r--r--  1 runner docker      170 Mar 27 17:51 clang-apply-replacements-19_linux-amd64.sha512sum
-rw-r--r--  1 runner docker  4179056 Mar 27 17:51 clang-format-19_linux-amd64
-rw-r--r--  1 runner docker      158 Mar 27 17:51 clang-format-19_linux-amd64.sha512sum
-rw-r--r--  1 runner docker 25835328 Mar 27 17:51 clang-query-19_linux-amd64
-rw-r--r--  1 runner docker      157 Mar 27 17:51 clang-query-19_linux-amd64.sha512sum
-rw-r--r--  1 runner docker 71481480 Mar 27 17:51 clang-tidy-19_linux-amd64
-rw-r--r--  1 runner docker      156 Mar 27 17:51 clang-tidy-19_linux-amd64.sha512sum

./clang-tools-llvm-project-19.1.0.src-19_macosx-amd64:
total 2141544
drwxr-xr-x  2 runner docker       4096 Mar 27 17:53 .
drwxr-xr-x 59 runner docker       4096 Mar 27 17:51 ..
-rw-r--r--  1 runner docker    3603104 Mar 27 17:51 clang-apply-replacements-19_macosx-amd64
-rw-r--r--  1 runner docker        171 Mar 27 17:51 clang-apply-replacements-19_macosx-amd64.sha512sum
-rw-r--r--  1 runner docker    4446688 Mar 27 17:51 clang-format-19_macosx-amd64
-rw-r--r--  1 runner docker        159 Mar 27 17:51 clang-format-19_macosx-amd64.sha512sum
-rw-r--r--  1 runner docker   37778728 Mar 27 17:51 clang-query-19_macosx-amd64
-rw-r--r--  1 runner docker        158 Mar 27 17:51 clang-query-19_macosx-amd64.sha512sum
-rw-r--r--  1 runner docker 2147075024 Mar 27 17:53 clang-tidy-19_macosx-amd64
-rw-r--r--  1 runner docker        157 Mar 27 17:53 clang-tidy-19_macosx-amd64.sha512sum

./clang-tools-llvm-project-19.1.0.src-19_windows-amd64:
total 94160
drwxr-xr-x  2 runner docker     4096 Mar 27 17:51 .
drwxr-xr-x 59 runner docker     4096 Mar 27 17:51 ..
-rw-r--r--  1 runner docker  3041280 Mar 27 17:51 clang-apply-replacements-19_windows-amd64.exe
-rw-r--r--  1 runner docker      172 Mar 27 17:51 clang-apply-replacements-19_windows-amd64.sha512sum
-rw-r--r--  1 runner docker  2849280 Mar 27 17:51 clang-format-19_windows-amd64.exe
-rw-r--r--  1 runner docker      160 Mar 27 17:51 clang-format-19_windows-amd64.sha512sum
-rw-r--r--  1 runner docker 26729984 Mar 27 17:51 clang-query-19_windows-amd64.exe
-rw-r--r--  1 runner docker      159 Mar 27 17:51 clang-query-19_windows-amd64.sha512sum
-rw-r--r--  1 runner docker 63769088 Mar 27 17:51 clang-tidy-19_windows-amd64.exe
-rw-r--r--  1 runner docker      158 Mar 27 17:51 clang-tidy-19_windows-amd64.sha512sum

./clang-tools-llvm-project-20.1.0.src-20_linux-amd64:
total 106580
drwxr-xr-x  2 runner docker     4096 Mar 27 17:51 .
drwxr-xr-x 59 runner docker     4096 Mar 27 17:51 ..
-rw-r--r--  1 runner docker  4121456 Mar 27 17:51 clang-apply-replacements-20_linux-amd64
-rw-r--r--  1 runner docker      170 Mar 27 17:51 clang-apply-replacements-20_linux-amd64.sha512sum
-rw-r--r--  1 runner docker  4252784 Mar 27 17:51 clang-format-20_linux-amd64
-rw-r--r--  1 runner docker      158 Mar 27 17:51 clang-format-20_linux-amd64.sha512sum
-rw-r--r--  1 runner docker 26527424 Mar 27 17:51 clang-query-20_linux-amd64
-rw-r--r--  1 runner docker      157 Mar 27 17:51 clang-query-20_linux-amd64.sha512sum
-rw-r--r--  1 runner docker 74201160 Mar 27 17:51 clang-tidy-20_linux-amd64
-rw-r--r--  1 runner docker      156 Mar 27 17:51 clang-tidy-20_linux-amd64.sha512sum

./clang-tools-llvm-project-20.1.0.src-20_macosx-amd64:
total 2156700
drwxr-xr-x  2 runner docker       4096 Mar 27 17:53 .
drwxr-xr-x 59 runner docker       4096 Mar 27 17:51 ..
-rw-r--r--  1 runner docker    [436](https://github.com/muttleyxd/clang-tools-static-binaries/actions/runs/14106644358/job/39537574961#step:3:437)6720 Mar 27 17:51 clang-apply-replacements-20_macosx-amd64
-rw-r--r--  1 runner docker        171 Mar 27 17:51 clang-apply-replacements-20_macosx-amd64.sha512sum
-rw-r--r--  1 runner docker    4531752 Mar 27 17:51 clang-format-20_macosx-amd64
-rw-r--r--  1 runner docker        159 Mar 27 17:51 clang-format-20_macosx-amd64.sha512sum
-rw-r--r--  1 runner docker   38634992 Mar 27 17:51 clang-query-20_macosx-amd64
-rw-r--r--  1 runner docker        158 Mar 27 17:51 clang-query-20_macosx-amd64.sha512sum
-rw-r--r--  1 runner docker 2160888280 Mar 27 17:53 clang-tidy-20_macosx-amd64
-rw-r--r--  1 runner docker        157 Mar 27 17:53 clang-tidy-20_macosx-amd64.sha512sum

./clang-tools-llvm-project-20.1.0.src-20_windows-amd64:
total 96552
drwxr-xr-x  2 runner docker     4096 Mar 27 17:51 .
drwxr-xr-x 59 runner docker     4096 Mar 27 17:51 ..
-rw-r--r--  1 runner docker  3103744 Mar 27 17:51 clang-apply-replacements-20_windows-amd64.exe
-rw-r--r--  1 runner docker      172 Mar 27 17:51 clang-apply-replacements-20_windows-amd64.sha512sum
-rw-r--r--  1 runner docker  2889728 Mar 27 17:51 clang-format-20_windows-amd64.exe
-rw-r--r--  1 runner docker      160 Mar 27 17:51 clang-format-20_windows-amd64.sha512sum
-rw-r--r--  1 runner docker 26971648 Mar 27 17:51 clang-query-20_windows-amd64.exe
-rw-r--r--  1 runner docker      159 Mar 27 17:51 clang-query-20_windows-amd64.sha512sum
-rw-r--r--  1 runner docker 65873920 Mar 27 17:51 clang-tidy-20_windows-amd64.exe
-rw-r--r--  1 runner docker      158 Mar 27 17:51 clang-tidy-20_windows-amd64.sha512sum
```