### PR TITLE
Feature: Test binaries during build process

### DIFF
--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -10,48 +10,48 @@ jobs:
       matrix:
         #clang-version: [ 3.9, 4, 5, 6, 7, 8, 9, 10, 11, 12, 12.0.1, 13, 14, 15, 16, 17, 18, 19, 20 ]
         # test
-        clang-version: [ 18, 19 ]
+        clang-version: [ 20 ]
         os: [ linux, macosx, windows ]
         include:
-          - clang-version: 3.9
-            release: llvm-project-3.9.1
-          - clang-version: 4
-            release: llvm-project-4.0.1
-          - clang-version: 5
-            release: llvm-project-5.0.2
-          - clang-version: 6
-            release: llvm-project-6.0.1
-          - clang-version: 7
-            release: llvm-project-7.1.0
-          - clang-version: 8
-            release: llvm-project-8.0.1
-            extra-cmake-args: '-DCLANG_ANALYZER_ENABLE_Z3_SOLVER=OFF'
-          - clang-version: 9
-            release: llvm-project-9.0.1
-            extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
-          - clang-version: 10
-            release: llvm-project-10.0.1
-            extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
-          - clang-version: 11
-            release: llvm-project-11.1.0.src
-          - clang-version: 12
-            release: llvm-project-12.0.0.src
-          - clang-version: 12.0.1
-            release: llvm-project-12.0.1.src
-          - clang-version: 13
-            release: llvm-project-13.0.0.src
-          - clang-version: 14
-            release: llvm-project-14.0.0.src
-          - clang-version: 15
-            release: llvm-project-15.0.2.src
-          - clang-version: 16
-            release: llvm-project-16.0.3.src
-          - clang-version: 17
-            release: llvm-project-17.0.4.src
-          - clang-version: 18
-            release: llvm-project-18.1.8.src
-          - clang-version: 19
-            release: llvm-project-19.1.0.src
+          #- clang-version: 3.9
+            #release: llvm-project-3.9.1
+          #- clang-version: 4
+            #release: llvm-project-4.0.1
+          #- clang-version: 5
+            #release: llvm-project-5.0.2
+          #- clang-version: 6
+            #release: llvm-project-6.0.1
+          #- clang-version: 7
+            #release: llvm-project-7.1.0
+          #- clang-version: 8
+            #release: llvm-project-8.0.1
+            #extra-cmake-args: '-DCLANG_ANALYZER_ENABLE_Z3_SOLVER=OFF'
+          #- clang-version: 9
+            #release: llvm-project-9.0.1
+            #extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
+          #- clang-version: 10
+            #release: llvm-project-10.0.1
+            #extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
+          #- clang-version: 11
+            #release: llvm-project-11.1.0.src
+          #- clang-version: 12
+            #release: llvm-project-12.0.0.src
+          #- clang-version: 12.0.1
+            #release: llvm-project-12.0.1.src
+          #- clang-version: 13
+            #release: llvm-project-13.0.0.src
+          #- clang-version: 14
+            #release: llvm-project-14.0.0.src
+          #- clang-version: 15
+            #release: llvm-project-15.0.2.src
+          #- clang-version: 16
+            #release: llvm-project-16.0.3.src
+          #- clang-version: 17
+            #release: llvm-project-17.0.4.src
+          #- clang-version: 18
+            #release: llvm-project-18.1.8.src
+          #- clang-version: 19
+            #release: llvm-project-19.1.0.src
           - clang-version: 20
             release: llvm-project-20.1.0.src
           - os: linux

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -8,50 +8,48 @@ jobs:
   build:
     strategy:
       matrix:
-        #clang-version: [ 3.9, 4, 5, 6, 7, 8, 9, 10, 11, 12, 12.0.1, 13, 14, 15, 16, 17, 18, 19, 20 ]
-        # test
-        clang-version: [ 20 ]
+        clang-version: [ 3.9, 4, 5, 6, 7, 8, 9, 10, 11, 12, 12.0.1, 13, 14, 15, 16, 17, 18, 19, 20 ]
         os: [ linux, macosx, windows ]
         include:
-          #- clang-version: 3.9
-            #release: llvm-project-3.9.1
-          #- clang-version: 4
-            #release: llvm-project-4.0.1
-          #- clang-version: 5
-            #release: llvm-project-5.0.2
-          #- clang-version: 6
-            #release: llvm-project-6.0.1
-          #- clang-version: 7
-            #release: llvm-project-7.1.0
-          #- clang-version: 8
-            #release: llvm-project-8.0.1
-            #extra-cmake-args: '-DCLANG_ANALYZER_ENABLE_Z3_SOLVER=OFF'
-          #- clang-version: 9
-            #release: llvm-project-9.0.1
-            #extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
-          #- clang-version: 10
-            #release: llvm-project-10.0.1
-            #extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
-          #- clang-version: 11
-            #release: llvm-project-11.1.0.src
-          #- clang-version: 12
-            #release: llvm-project-12.0.0.src
-          #- clang-version: 12.0.1
-            #release: llvm-project-12.0.1.src
-          #- clang-version: 13
-            #release: llvm-project-13.0.0.src
-          #- clang-version: 14
-            #release: llvm-project-14.0.0.src
-          #- clang-version: 15
-            #release: llvm-project-15.0.2.src
-          #- clang-version: 16
-            #release: llvm-project-16.0.3.src
-          #- clang-version: 17
-            #release: llvm-project-17.0.4.src
-          #- clang-version: 18
-            #release: llvm-project-18.1.8.src
-          #- clang-version: 19
-            #release: llvm-project-19.1.0.src
+          - clang-version: 3.9
+            release: llvm-project-3.9.1
+          - clang-version: 4
+            release: llvm-project-4.0.1
+          - clang-version: 5
+            release: llvm-project-5.0.2
+          - clang-version: 6
+            release: llvm-project-6.0.1
+          - clang-version: 7
+            release: llvm-project-7.1.0
+          - clang-version: 8
+            release: llvm-project-8.0.1
+            extra-cmake-args: '-DCLANG_ANALYZER_ENABLE_Z3_SOLVER=OFF'
+          - clang-version: 9
+            release: llvm-project-9.0.1
+            extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
+          - clang-version: 10
+            release: llvm-project-10.0.1
+            extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
+          - clang-version: 11
+            release: llvm-project-11.1.0.src
+          - clang-version: 12
+            release: llvm-project-12.0.0.src
+          - clang-version: 12.0.1
+            release: llvm-project-12.0.1.src
+          - clang-version: 13
+            release: llvm-project-13.0.0.src
+          - clang-version: 14
+            release: llvm-project-14.0.0.src
+          - clang-version: 15
+            release: llvm-project-15.0.2.src
+          - clang-version: 16
+            release: llvm-project-16.0.3.src
+          - clang-version: 17
+            release: llvm-project-17.0.4.src
+          - clang-version: 18
+            release: llvm-project-18.1.8.src
+          - clang-version: 19
+            release: llvm-project-19.1.0.src
           - clang-version: 20
             release: llvm-project-20.1.0.src
           - os: linux

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -225,7 +225,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: artifacts
-          pattern: '*${{ matrix.suffix }}'
+          pattern: '*${{ env.suffix }}'
       - name: list files
         run: ls -laR artifacts/
       - name: smoke test each clang tool

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -240,6 +240,7 @@ jobs:
             if [[ $tool == *.sha512sum ]]; then
               continue
             fi
+            chmod +x $tool
             # Run the tool with --version and print the output
             echo "Running $tool --version"
             $tool --version

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         #clang-version: [ 3.9, 4, 5, 6, 7, 8, 9, 10, 11, 12, 12.0.1, 13, 14, 15, 16, 17, 18, 19, 20 ]
         # test
-        clang-version: [ 19 ]
+        clang-version: [ 18, 19 ]
         os: [ linux, macosx, windows ]
         include:
           - clang-version: 3.9
@@ -81,7 +81,6 @@ jobs:
           # TODO: macosx clang 18 is failing.  Example: https://github.com/colinsullivan/clang-tools-static-binaries/actions/runs/14976168180/job/42068957048
           - os: macosx
             clang-version: 18
-
     runs-on: ${{ matrix.runner }}
     env:
       COMMON_CMAKE_ARGS: '-DBUILD_SHARED_LIBS=OFF -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra"'

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -226,7 +226,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: artifacts
-          pattern: '*${{ env.suffix }}'
+          pattern: '**/*${{ env.suffix }}'
       - name: list files (macos, linux)
         if: ${{ matrix.os == 'macosx' || matrix.os == 'linux' }}
         run: ls -laR artifacts/

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -218,12 +218,14 @@ jobs:
             runner: windows-latest
     runs-on: ${{ matrix.runner }}
     needs: build
+    env:
+      suffix: '_${{ matrix.os }}-amd64'
     steps:
       - name: download artifacts
         uses: actions/download-artifact@v4
         with:
           path: artifacts
-          pattern: '*${{ matrix.os }}*'
+          pattern: '*${{ matrix.suffix }}'
       - name: list files
         run: ls -laR artifacts/
       - name: smoke test each clang tool

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -8,7 +8,9 @@ jobs:
   build:
     strategy:
       matrix:
-        clang-version: [ 3.9, 4, 5, 6, 7, 8, 9, 10, 11, 12, 12.0.1, 13, 14, 15, 16, 17, 18, 19, 20 ]
+        #clang-version: [ 3.9, 4, 5, 6, 7, 8, 9, 10, 11, 12, 12.0.1, 13, 14, 15, 16, 17, 18, 19, 20 ]
+        # test
+        clang-version: [ 19 ]
         os: [ linux, macosx, windows ]
         include:
           - clang-version: 3.9

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -240,7 +240,6 @@ jobs:
             if [[ $tool == *.sha512sum ]]; then
               continue
             fi
-            chmod +x $tool
             # Run the tool with --version and print the output
             echo "Running $tool --version"
             $tool --version

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -228,9 +228,11 @@ jobs:
         with:
           path: artifacts
           pattern: '*${{ env.suffix }}'
-      - name: list files
+      - name: list files (macos, linux)
+        if: ${{ matrix.os == 'macosx' || matrix.os == 'linux' }}
         run: ls -laR artifacts/
-      - name: smoke test each clang tool
+      - name: smoke test each clang tool (macos, linux)
+        if: ${{ matrix.os == 'macosx' || matrix.os == 'linux' }}
         run: |
           cd artifacts
           # From the artifacts directory, loop over each executable

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -231,9 +231,16 @@ jobs:
       - name: smoke test each clang tool
         run: |
           cd artifacts
-          # From the artifacts directory, loop over each executable and 
-          # invoke the --version command
+          # From the artifacts directory, loop over each executable
+          # (not .sha512sum files) and 
+          # invoke the --version command to verify
+          
           for tool in $(find . -type f); do
+            # Skip the sha512sum files
+            if [[ $tool == *.sha512sum ]]; then
+              continue
+            fi
+            # Run the tool with --version and print the output
             echo "Running $tool --version"
             $tool --version
           done

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -237,7 +237,7 @@ jobs:
           done
   draft-release:
     runs-on: ubuntu-22.04
-    needs: build
+    needs: [build, test-release]
     steps:
       - name: download artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -248,6 +248,34 @@ jobs:
             echo "Running $tool --version"
             $tool --version
           done
+      - name: List files (Windows)
+        if: ${{ matrix.os == 'windows' }}
+        run: |
+          Get-ChildItem -Recurse artifacts | Format-List
+
+      - name: Smoke test each clang tool (Windows)
+        if: ${{ matrix.os == 'windows' }}
+        shell: pwsh
+        run: |
+          Set-Location artifacts
+
+          # Find all files excluding *.sha512sum
+          $tools = Get-ChildItem -Recurse -File | Where-Object { $_.Name -notlike '*.sha512sum' }
+
+          foreach ($tool in $tools) {
+              # Ensure the file is executable
+              $toolPath = $tool.FullName
+
+              # Print which tool is being run
+              Write-Host "Running $toolPath --version"
+
+              try {
+                  # Attempt to run the tool with --version
+                  & $toolPath --version
+              } catch {
+                  Write-Host "Failed to run $toolPath --version. Error: $_"
+              }
+          }
   draft-release:
     runs-on: ubuntu-22.04
     needs: [build, test-release]

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -158,6 +158,22 @@ jobs:
     - name: print dependencies
       if: ${{ matrix.os == 'macosx' }}
       run: otool -L ${{ matrix.release }}/build/bin/clang-format
+    - name: smoke test clang-tools (macos, linux)
+      if: ${{ matrix.os == 'macosx' || matrix.os == 'linux' }}
+      run: |
+        cd ${{ matrix.release }}/build/bin
+        ./clang-format --version
+        ./clang-query --version
+        ./clang-tidy --version
+        ./clang-apply-replacements --version
+    - name: smoke test clang-tools (windows)
+      if: ${{ matrix.os == 'windows' }}
+      run: |
+        cd ${{ matrix.release }}${{ matrix.bindir }}
+        clang-format${{ matrix.dotexe }} --version
+        clang-query${{ matrix.dotexe }} --version
+        clang-tidy${{ matrix.dotexe }} --version
+        clang-apply-replacements${{ matrix.dotexe }} --version
     - name: rename output binary
       run: |
         cd ${{ matrix.release }}${{ matrix.bindir }}

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -205,6 +205,36 @@ jobs:
         name: clang-tools-${{ matrix.release }}-${{ env.suffix }}
         path: "${{ matrix.release }}${{ matrix.bindir }}/clang-*-${{ env.suffix }}*"
         retention-days: 1
+  test-release:
+    strategy:
+      matrix:
+        os: [ linux, macosx, windows ]
+        include:
+          - os: linux
+            runner: ubuntu-22.04
+          - os: macosx
+            runner: macos-13
+          - os: windows
+            runner: windows-latest
+    runs-on: ${{ matrix.runner }}
+    needs: build
+    steps:
+      - name: download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: '*${{ matrix.os }}*'
+      - name: list files
+        run: ls -laR artifacts/
+      - name: smoke test each clang tool
+        run: |
+          cd artifacts
+          # From the artifacts directory, loop over each executable and 
+          # invoke the --version command
+          for tool in $(find . -type f); do
+            echo "Running $tool --version"
+            $tool --version
+          done
   draft-release:
     runs-on: ubuntu-22.04
     needs: build

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -2,7 +2,7 @@ name: clang-tools-static-amd64
 
 on:
   push:
-    branches: [ master]
+    branches: [ master, test-binaries ]
 
 jobs:
   build:


### PR DESCRIPTION
Introduces two test stages for mac , linux , and windows:

1) test the binaries directly after building them, this would fail the build sooner
2) test all binaries on a fresh VM, this would catch portability issues such as the "rpath" issue in the error below.

This would have prevented the bug introduced in this PR: https://github.com/muttleyxd/clang-tools-static-binaries/pull/59 because all binaries would have been smoke tested before release.  Example, this pipeline fails: https://github.com/colinsullivan/clang-tools-static-binaries/actions/runs/15075001213/job/42386935465