### PR TITLE
Fix: macos intel builds fixed

### DIFF
--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -62,7 +62,7 @@ jobs:
             shacmd: 'sha512sum'
           - os: macosx
             runner: macos-14
-            os-cmake-args: '-DCMAKE_CXX_FLAGS="-static-libgcc -static-libstdc++ -flto" -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 ${POSIX_CMAKE_ARGS} ${MACOS_CMAKE_ARGS}'
+            os-cmake-args: '-DCMAKE_CXX_FLAGS="-static-libgcc -static-libstdc++ -flto" -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 ${POSIX_CMAKE_ARGS} ${MACOS_CMAKE_ARGS} -DLLVM_TARGETS_TO_BUILD=X86'
             build-args: '-j$(sysctl -n hw.ncpu)'
             bindir: '/build/bin'
             dotexe: ''

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -8,43 +8,42 @@ jobs:
   build:
     strategy:
       matrix:
-        #clang-version: [ 3.9, 4, 5, 6, 7, 8, 9, 10, 11, 12, 12.0.1, 13, 14, 15, 16, 17, 18, 19, 20 ]
-        clang-version: [ 17, 18, 19, 20 ]
+        clang-version: [ 3.9, 4, 5, 6, 7, 8, 9, 10, 11, 12, 12.0.1, 13, 14, 15, 16, 17, 18, 19, 20 ]
         os: [ linux, macosx, windows ]
         include:
-          #- clang-version: 3.9
-            #release: llvm-project-3.9.1
-          #- clang-version: 4
-            #release: llvm-project-4.0.1
-          #- clang-version: 5
-            #release: llvm-project-5.0.2
-          #- clang-version: 6
-            #release: llvm-project-6.0.1
-          #- clang-version: 7
-            #release: llvm-project-7.1.0
-          #- clang-version: 8
-            #release: llvm-project-8.0.1
-            #extra-cmake-args: '-DCLANG_ANALYZER_ENABLE_Z3_SOLVER=OFF'
-          #- clang-version: 9
-            #release: llvm-project-9.0.1
-            #extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
-          #- clang-version: 10
-            #release: llvm-project-10.0.1
-            #extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
-          #- clang-version: 11
-            #release: llvm-project-11.1.0.src
-          #- clang-version: 12
-            #release: llvm-project-12.0.0.src
-          #- clang-version: 12.0.1
-            #release: llvm-project-12.0.1.src
-          #- clang-version: 13
-            #release: llvm-project-13.0.0.src
-          #- clang-version: 14
-            #release: llvm-project-14.0.0.src
-          #- clang-version: 15
-            #release: llvm-project-15.0.2.src
-          #- clang-version: 16
-            #release: llvm-project-16.0.3.src
+          - clang-version: 3.9
+            release: llvm-project-3.9.1
+          - clang-version: 4
+            release: llvm-project-4.0.1
+          - clang-version: 5
+            release: llvm-project-5.0.2
+          - clang-version: 6
+            release: llvm-project-6.0.1
+          - clang-version: 7
+            release: llvm-project-7.1.0
+          - clang-version: 8
+            release: llvm-project-8.0.1
+            extra-cmake-args: '-DCLANG_ANALYZER_ENABLE_Z3_SOLVER=OFF'
+          - clang-version: 9
+            release: llvm-project-9.0.1
+            extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
+          - clang-version: 10
+            release: llvm-project-10.0.1
+            extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
+          - clang-version: 11
+            release: llvm-project-11.1.0.src
+          - clang-version: 12
+            release: llvm-project-12.0.0.src
+          - clang-version: 12.0.1
+            release: llvm-project-12.0.1.src
+          - clang-version: 13
+            release: llvm-project-13.0.0.src
+          - clang-version: 14
+            release: llvm-project-14.0.0.src
+          - clang-version: 15
+            release: llvm-project-15.0.2.src
+          - clang-version: 16
+            release: llvm-project-16.0.3.src
           - clang-version: 17
             release: llvm-project-17.0.6.src
           - clang-version: 18

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -76,6 +76,11 @@ jobs:
             shacmd: 'sha512sum.exe'
             extra-tar-args: '--exclude=${RELEASE}/clang/test/Driver/Inputs/* --exclude=${RELEASE}/libcxx/test/std/input.output/filesystems/Inputs/static_test_env/* --exclude=${RELEASE}/libclc/amdgcn-mesa3d'
             extra-tar-args-cfe: '--exclude=cfe-${version}.src/test/Driver/Inputs/*'
+        exclude:
+          # TODO: 17 cannot be built on macos arm
+          # See https://github.com/llvm/llvm-project/issues/106521
+          - os: macos
+            clang-version: 17
     runs-on: ${{ matrix.runner }}
     env:
       COMMON_CMAKE_ARGS: '-DBUILD_SHARED_LIBS=OFF -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra"'
@@ -217,7 +222,7 @@ jobs:
           - os: linux
             runner: ubuntu-22.04
           - os: macosx
-            runner: macos-13
+            runner: macos-13 # Intel macOS runner test
           - os: windows
             runner: windows-latest
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -13,49 +13,37 @@ jobs:
         include:
           - clang-version: 3.9
             release: llvm-project-3.9.1
-            extra-cmake-args: '-DCMAKE_CXX_STANDARD=14'
           - clang-version: 4
             release: llvm-project-4.0.1
-            extra-cmake-args: '-DCMAKE_CXX_STANDARD=14'
           - clang-version: 5
             release: llvm-project-5.0.2
-            extra-cmake-args: '-DCMAKE_CXX_STANDARD=14'
           - clang-version: 6
             release: llvm-project-6.0.1
-            extra-cmake-args: '-DCMAKE_CXX_STANDARD=14'
           - clang-version: 7
             release: llvm-project-7.1.0
-            extra-cmake-args: '-DCMAKE_CXX_STANDARD=14'
           - clang-version: 8
             release: llvm-project-8.0.1
-            extra-cmake-args: '-DCLANG_ANALYZER_ENABLE_Z3_SOLVER=OFF -DCMAKE_CXX_STANDARD=14'
+            extra-cmake-args: '-DCLANG_ANALYZER_ENABLE_Z3_SOLVER=OFF'
           - clang-version: 9
             release: llvm-project-9.0.1
-            extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF -DCMAKE_CXX_STANDARD=14'
+            extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
           - clang-version: 10
             release: llvm-project-10.0.1
-            extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF -DCMAKE_CXX_STANDARD=17'
+            extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
           - clang-version: 11
             release: llvm-project-11.1.0.src
-            extra-cmake-args: '-DCMAKE_CXX_STANDARD=17'
           - clang-version: 12
             release: llvm-project-12.0.0.src
-            extra-cmake-args: '-DCMAKE_CXX_STANDARD=17'
           - clang-version: 12.0.1
             release: llvm-project-12.0.1.src
-            extra-cmake-args: '-DCMAKE_CXX_STANDARD=17'
           - clang-version: 13
             release: llvm-project-13.0.0.src
-            extra-cmake-args: '-DCMAKE_CXX_STANDARD=17'
           - clang-version: 14
             release: llvm-project-14.0.0.src
-            extra-cmake-args: '-DCMAKE_CXX_STANDARD=17'
           - clang-version: 15
             release: llvm-project-15.0.2.src
-            extra-cmake-args: '-DCMAKE_CXX_STANDARD=17'
           - clang-version: 16
             release: llvm-project-16.0.3.src
-            extra-cmake-args: '-DCMAKE_CXX_STANDARD=17'
           - clang-version: 17
             release: llvm-project-17.0.4.src
             extra-cmake-args: '-DCMAKE_CXX_STANDARD=17'

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -8,51 +8,50 @@ jobs:
   build:
     strategy:
       matrix:
-        #clang-version: [ 3.9, 4, 5, 6, 7, 8, 9, 10, 11, 12, 12.0.1, 13, 14, 15, 16, 17, 18, 19, 20 ]
-        clang-version: [ 18 ]
+        clang-version: [ 3.9, 4, 5, 6, 7, 8, 9, 10, 11, 12, 12.0.1, 13, 14, 15, 16, 17, 18, 19, 20 ]
         os: [ linux, macosx, windows ]
         include:
-          #- clang-version: 3.9
-            #release: llvm-project-3.9.1
-          #- clang-version: 4
-            #release: llvm-project-4.0.1
-          #- clang-version: 5
-            #release: llvm-project-5.0.2
-          #- clang-version: 6
-            #release: llvm-project-6.0.1
-          #- clang-version: 7
-            #release: llvm-project-7.1.0
-          #- clang-version: 8
-            #release: llvm-project-8.0.1
-            #extra-cmake-args: '-DCLANG_ANALYZER_ENABLE_Z3_SOLVER=OFF'
-          #- clang-version: 9
-            #release: llvm-project-9.0.1
-            #extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
-          #- clang-version: 10
-            #release: llvm-project-10.0.1
-            #extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
-          #- clang-version: 11
-            #release: llvm-project-11.1.0.src
-          #- clang-version: 12
-            #release: llvm-project-12.0.0.src
-          #- clang-version: 12.0.1
-            #release: llvm-project-12.0.1.src
-          #- clang-version: 13
-            #release: llvm-project-13.0.0.src
-          #- clang-version: 14
-            #release: llvm-project-14.0.0.src
-          #- clang-version: 15
-            #release: llvm-project-15.0.2.src
-          #- clang-version: 16
-            #release: llvm-project-16.0.3.src
-          #- clang-version: 17
-            #release: llvm-project-17.0.4.src
+          - clang-version: 3.9
+            release: llvm-project-3.9.1
+          - clang-version: 4
+            release: llvm-project-4.0.1
+          - clang-version: 5
+            release: llvm-project-5.0.2
+          - clang-version: 6
+            release: llvm-project-6.0.1
+          - clang-version: 7
+            release: llvm-project-7.1.0
+          - clang-version: 8
+            release: llvm-project-8.0.1
+            extra-cmake-args: '-DCLANG_ANALYZER_ENABLE_Z3_SOLVER=OFF'
+          - clang-version: 9
+            release: llvm-project-9.0.1
+            extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
+          - clang-version: 10
+            release: llvm-project-10.0.1
+            extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
+          - clang-version: 11
+            release: llvm-project-11.1.0.src
+          - clang-version: 12
+            release: llvm-project-12.0.0.src
+          - clang-version: 12.0.1
+            release: llvm-project-12.0.1.src
+          - clang-version: 13
+            release: llvm-project-13.0.0.src
+          - clang-version: 14
+            release: llvm-project-14.0.0.src
+          - clang-version: 15
+            release: llvm-project-15.0.2.src
+          - clang-version: 16
+            release: llvm-project-16.0.3.src
+          - clang-version: 17
+            release: llvm-project-17.0.4.src
           - clang-version: 18
             release: llvm-project-18.1.8.src
-          #- clang-version: 19
-            #release: llvm-project-19.1.0.src
-          #- clang-version: 20
-            #release: llvm-project-20.1.0.src
+          - clang-version: 19
+            release: llvm-project-19.1.0.src
+          - clang-version: 20
+            release: llvm-project-20.1.0.src
           - os: linux
             runner: ubuntu-22.04
             os-cmake-args: '-DLLVM_BUILD_STATIC=ON -DCMAKE_CXX_FLAGS="-s -flto" ${POSIX_CMAKE_ARGS} ${LINUX_CMAKE_ARGS}'

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -85,13 +85,6 @@ jobs:
       RELEASE: '${{ matrix.release }}'
       suffix: '${{ matrix.clang-version }}_${{ matrix.os }}-amd64'
     steps:
-    - name: Update homebrew
-      if: ${{ matrix.os == 'macosx' && matrix.clang-version >= '17' }}
-      shell: bash
-      run: |
-        brew update
-        brew upgrade
-        brew cleanup
     - name: download patches
       # we download a tarball of this repo, as the presence of a .git directory leaks
       # the commit hash of this repository into the clang binaries

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -46,7 +46,7 @@ jobs:
           #- clang-version: 16
             #release: llvm-project-16.0.3.src
           - clang-version: 17
-            release: llvm-project-17.0.4.src
+            release: llvm-project-17.0.6.src
           - clang-version: 18
             release: llvm-project-18.1.8.src
           - clang-version: 19

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -13,45 +13,61 @@ jobs:
         include:
           - clang-version: 3.9
             release: llvm-project-3.9.1
+            extra-cmake-args: '-DCMAKE_CXX_STANDARD=14'
           - clang-version: 4
             release: llvm-project-4.0.1
+            extra-cmake-args: '-DCMAKE_CXX_STANDARD=14'
           - clang-version: 5
             release: llvm-project-5.0.2
+            extra-cmake-args: '-DCMAKE_CXX_STANDARD=14'
           - clang-version: 6
             release: llvm-project-6.0.1
+            extra-cmake-args: '-DCMAKE_CXX_STANDARD=14'
           - clang-version: 7
             release: llvm-project-7.1.0
+            extra-cmake-args: '-DCMAKE_CXX_STANDARD=14'
           - clang-version: 8
             release: llvm-project-8.0.1
-            extra-cmake-args: '-DCLANG_ANALYZER_ENABLE_Z3_SOLVER=OFF'
+            extra-cmake-args: '-DCLANG_ANALYZER_ENABLE_Z3_SOLVER=OFF -DCMAKE_CXX_STANDARD=14'
           - clang-version: 9
             release: llvm-project-9.0.1
-            extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
+            extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OF -DCMAKE_CXX_STANDARD=14'
           - clang-version: 10
             release: llvm-project-10.0.1
-            extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
+            extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF -DCMAKE_CXX_STANDARD=17'
           - clang-version: 11
             release: llvm-project-11.1.0.src
+            extra-cmake-args: '-DCMAKE_CXX_STANDARD=17'
           - clang-version: 12
             release: llvm-project-12.0.0.src
+            extra-cmake-args: '-DCMAKE_CXX_STANDARD=17'
           - clang-version: 12.0.1
             release: llvm-project-12.0.1.src
+            extra-cmake-args: '-DCMAKE_CXX_STANDARD=17'
           - clang-version: 13
             release: llvm-project-13.0.0.src
+            extra-cmake-args: '-DCMAKE_CXX_STANDARD=17'
           - clang-version: 14
             release: llvm-project-14.0.0.src
+            extra-cmake-args: '-DCMAKE_CXX_STANDARD=17'
           - clang-version: 15
             release: llvm-project-15.0.2.src
+            extra-cmake-args: '-DCMAKE_CXX_STANDARD=17'
           - clang-version: 16
             release: llvm-project-16.0.3.src
+            extra-cmake-args: '-DCMAKE_CXX_STANDARD=17'
           - clang-version: 17
             release: llvm-project-17.0.4.src
+            extra-cmake-args: '-DCMAKE_CXX_STANDARD=17'
           - clang-version: 18
             release: llvm-project-18.1.8.src
+            extra-cmake-args: '-DCMAKE_CXX_STANDARD=17'
           - clang-version: 19
             release: llvm-project-19.1.0.src
+            extra-cmake-args: '-DCMAKE_CXX_STANDARD=17'
           - clang-version: 20
             release: llvm-project-20.1.0.src
+            extra-cmake-args: '-DCMAKE_CXX_STANDARD=17'
           - os: linux
             runner: ubuntu-22.04
             os-cmake-args: '-DLLVM_BUILD_STATIC=ON -DCMAKE_CXX_FLAGS="-s -flto" ${POSIX_CMAKE_ARGS} ${LINUX_CMAKE_ARGS}'
@@ -79,7 +95,7 @@ jobs:
     env:
       COMMON_CMAKE_ARGS: '-DBUILD_SHARED_LIBS=OFF -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra"'
       LINUX_CMAKE_ARGS: '-DCMAKE_CXX_COMPILER=g++-10 -DCMAKE_C_COMPILER=gcc-10'
-      MACOS_CMAKE_ARGS: '-DCMAKE_CXX_COMPILER=g++-14 -DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_STANDARD=17'
+      MACOS_CMAKE_ARGS: '-DCMAKE_CXX_COMPILER=g++-14 -DCMAKE_C_COMPILER=gcc-14'
       POSIX_CMAKE_ARGS: '-DCMAKE_BUILD_TYPE=MinSizeRel'
       RELEASE: '${{ matrix.release }}'
       suffix: '${{ matrix.clang-version }}_${{ matrix.os }}-amd64'

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -45,7 +45,7 @@ jobs:
           - clang-version: 16
             release: llvm-project-16.0.3.src
           - clang-version: 17
-            release: llvm-project-17.0.6.src
+            release: llvm-project-17.0.4.src
           - clang-version: 18
             release: llvm-project-18.1.8.src
           - clang-version: 19

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -2,56 +2,57 @@ name: clang-tools-static-amd64
 
 on:
   push:
-    branches: [ master, cmake-upgrade-fix ]
+    branches: [ master, 18-macos-fix ]
 
 jobs:
   build:
     strategy:
       matrix:
-        clang-version: [ 3.9, 4, 5, 6, 7, 8, 9, 10, 11, 12, 12.0.1, 13, 14, 15, 16, 17, 18, 19, 20 ]
+        #clang-version: [ 3.9, 4, 5, 6, 7, 8, 9, 10, 11, 12, 12.0.1, 13, 14, 15, 16, 17, 18, 19, 20 ]
+        clang-version: [ 18 ]
         os: [ linux, macosx, windows ]
         include:
-          - clang-version: 3.9
-            release: llvm-project-3.9.1
-          - clang-version: 4
-            release: llvm-project-4.0.1
-          - clang-version: 5
-            release: llvm-project-5.0.2
-          - clang-version: 6
-            release: llvm-project-6.0.1
-          - clang-version: 7
-            release: llvm-project-7.1.0
-          - clang-version: 8
-            release: llvm-project-8.0.1
-            extra-cmake-args: '-DCLANG_ANALYZER_ENABLE_Z3_SOLVER=OFF'
-          - clang-version: 9
-            release: llvm-project-9.0.1
-            extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
-          - clang-version: 10
-            release: llvm-project-10.0.1
-            extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
-          - clang-version: 11
-            release: llvm-project-11.1.0.src
-          - clang-version: 12
-            release: llvm-project-12.0.0.src
-          - clang-version: 12.0.1
-            release: llvm-project-12.0.1.src
-          - clang-version: 13
-            release: llvm-project-13.0.0.src
-          - clang-version: 14
-            release: llvm-project-14.0.0.src
-          - clang-version: 15
-            release: llvm-project-15.0.2.src
-          - clang-version: 16
-            release: llvm-project-16.0.3.src
-          - clang-version: 17
-            release: llvm-project-17.0.4.src
+          #- clang-version: 3.9
+            #release: llvm-project-3.9.1
+          #- clang-version: 4
+            #release: llvm-project-4.0.1
+          #- clang-version: 5
+            #release: llvm-project-5.0.2
+          #- clang-version: 6
+            #release: llvm-project-6.0.1
+          #- clang-version: 7
+            #release: llvm-project-7.1.0
+          #- clang-version: 8
+            #release: llvm-project-8.0.1
+            #extra-cmake-args: '-DCLANG_ANALYZER_ENABLE_Z3_SOLVER=OFF'
+          #- clang-version: 9
+            #release: llvm-project-9.0.1
+            #extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
+          #- clang-version: 10
+            #release: llvm-project-10.0.1
+            #extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
+          #- clang-version: 11
+            #release: llvm-project-11.1.0.src
+          #- clang-version: 12
+            #release: llvm-project-12.0.0.src
+          #- clang-version: 12.0.1
+            #release: llvm-project-12.0.1.src
+          #- clang-version: 13
+            #release: llvm-project-13.0.0.src
+          #- clang-version: 14
+            #release: llvm-project-14.0.0.src
+          #- clang-version: 15
+            #release: llvm-project-15.0.2.src
+          #- clang-version: 16
+            #release: llvm-project-16.0.3.src
+          #- clang-version: 17
+            #release: llvm-project-17.0.4.src
           - clang-version: 18
             release: llvm-project-18.1.8.src
-          - clang-version: 19
-            release: llvm-project-19.1.0.src
-          - clang-version: 20
-            release: llvm-project-20.1.0.src
+          #- clang-version: 19
+            #release: llvm-project-19.1.0.src
+          #- clang-version: 20
+            #release: llvm-project-20.1.0.src
           - os: linux
             runner: ubuntu-22.04
             os-cmake-args: '-DLLVM_BUILD_STATIC=ON -DCMAKE_CXX_FLAGS="-s -flto" ${POSIX_CMAKE_ARGS} ${LINUX_CMAKE_ARGS}'
@@ -60,7 +61,7 @@ jobs:
             dotexe: ''
             shacmd: 'sha512sum'
           - os: macosx
-            runner: macos-13
+            runner: macos-14
             os-cmake-args: '-DCMAKE_CXX_FLAGS="-static-libgcc -static-libstdc++ -flto" -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 ${POSIX_CMAKE_ARGS} ${MACOS_CMAKE_ARGS}'
             build-args: '-j$(sysctl -n hw.ncpu)'
             bindir: '/build/bin'
@@ -75,11 +76,6 @@ jobs:
             shacmd: 'sha512sum.exe'
             extra-tar-args: '--exclude=${RELEASE}/clang/test/Driver/Inputs/* --exclude=${RELEASE}/libcxx/test/std/input.output/filesystems/Inputs/static_test_env/* --exclude=${RELEASE}/libclc/amdgcn-mesa3d'
             extra-tar-args-cfe: '--exclude=cfe-${version}.src/test/Driver/Inputs/*'
-        exclude:
-          # TODO: macosx clang 18 is failing.  Example: https://github.com/colinsullivan/clang-tools-static-binaries/actions/runs/14976168180/job/42068957048
-          - os: macosx
-            clang-version: 18
-
     runs-on: ${{ matrix.runner }}
     env:
       COMMON_CMAKE_ARGS: '-DBUILD_SHARED_LIBS=OFF -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra"'

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         #clang-version: [ 3.9, 4, 5, 6, 7, 8, 9, 10, 11, 12, 12.0.1, 13, 14, 15, 16, 17, 18, 19, 20 ]
-        clang-version: [ 18, 19, 20 ]
+        clang-version: [ 17, 18, 19, 20 ]
         os: [ linux, macosx, windows ]
         include:
           #- clang-version: 3.9
@@ -45,8 +45,8 @@ jobs:
             #release: llvm-project-15.0.2.src
           #- clang-version: 16
             #release: llvm-project-16.0.3.src
-          #- clang-version: 17
-            #release: llvm-project-17.0.6.src
+          - clang-version: 17
+            release: llvm-project-17.0.6.src
           - clang-version: 18
             release: llvm-project-18.1.8.src
           - clang-version: 19
@@ -76,11 +76,6 @@ jobs:
             shacmd: 'sha512sum.exe'
             extra-tar-args: '--exclude=${RELEASE}/clang/test/Driver/Inputs/* --exclude=${RELEASE}/libcxx/test/std/input.output/filesystems/Inputs/static_test_env/* --exclude=${RELEASE}/libclc/amdgcn-mesa3d'
             extra-tar-args-cfe: '--exclude=cfe-${version}.src/test/Driver/Inputs/*'
-        exclude:
-          # TODO: 17 cannot be built on macos arm
-          # See https://github.com/llvm/llvm-project/issues/106521
-          - os: macos
-            clang-version: 17
     runs-on: ${{ matrix.runner }}
     env:
       COMMON_CMAKE_ARGS: '-DBUILD_SHARED_LIBS=OFF -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra"'

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -31,7 +31,7 @@ jobs:
             extra-cmake-args: '-DCLANG_ANALYZER_ENABLE_Z3_SOLVER=OFF -DCMAKE_CXX_STANDARD=14'
           - clang-version: 9
             release: llvm-project-9.0.1
-            extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OF -DCMAKE_CXX_STANDARD=14'
+            extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF -DCMAKE_CXX_STANDARD=14'
           - clang-version: 10
             release: llvm-project-10.0.1
             extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF -DCMAKE_CXX_STANDARD=17'

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -46,16 +46,16 @@ jobs:
             release: llvm-project-16.0.3.src
           - clang-version: 17
             release: llvm-project-17.0.4.src
-            extra-cmake-args: '-DCMAKE_CXX_STANDARD=17'
+            extra-cmake-args: '-DCMAKE_CXX_STANDARD=20'
           - clang-version: 18
             release: llvm-project-18.1.8.src
-            extra-cmake-args: '-DCMAKE_CXX_STANDARD=17'
+            extra-cmake-args: '-DCMAKE_CXX_STANDARD=20'
           - clang-version: 19
             release: llvm-project-19.1.0.src
-            extra-cmake-args: '-DCMAKE_CXX_STANDARD=17'
+            extra-cmake-args: '-DCMAKE_CXX_STANDARD=20'
           - clang-version: 20
             release: llvm-project-20.1.0.src
-            extra-cmake-args: '-DCMAKE_CXX_STANDARD=17'
+            extra-cmake-args: '-DCMAKE_CXX_STANDARD=20'
           - os: linux
             runner: ubuntu-22.04
             os-cmake-args: '-DLLVM_BUILD_STATIC=ON -DCMAKE_CXX_FLAGS="-s -flto" ${POSIX_CMAKE_ARGS} ${LINUX_CMAKE_ARGS}'

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -8,45 +8,44 @@ jobs:
   build:
     strategy:
       matrix:
-        #clang-version: [ 3.9, 4, 5, 6, 7, 8, 9, 10, 11, 12, 12.0.1, 13, 14, 15, 16, 17, 18, 19, 20 ]
-        clang-version: [ 18, 19, 20 ]
+        clang-version: [ 3.9, 4, 5, 6, 7, 8, 9, 10, 11, 12, 12.0.1, 13, 14, 15, 16, 17, 18, 19, 20 ]
         os: [ linux, macosx, windows ]
         include:
-          #- clang-version: 3.9
-            #release: llvm-project-3.9.1
-          #- clang-version: 4
-            #release: llvm-project-4.0.1
-          #- clang-version: 5
-            #release: llvm-project-5.0.2
-          #- clang-version: 6
-            #release: llvm-project-6.0.1
-          #- clang-version: 7
-            #release: llvm-project-7.1.0
-          #- clang-version: 8
-            #release: llvm-project-8.0.1
-            #extra-cmake-args: '-DCLANG_ANALYZER_ENABLE_Z3_SOLVER=OFF'
-          #- clang-version: 9
-            #release: llvm-project-9.0.1
-            #extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
-          #- clang-version: 10
-            #release: llvm-project-10.0.1
-            #extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
-          #- clang-version: 11
-            #release: llvm-project-11.1.0.src
-          #- clang-version: 12
-            #release: llvm-project-12.0.0.src
-          #- clang-version: 12.0.1
-            #release: llvm-project-12.0.1.src
-          #- clang-version: 13
-            #release: llvm-project-13.0.0.src
-          #- clang-version: 14
-            #release: llvm-project-14.0.0.src
-          #- clang-version: 15
-            #release: llvm-project-15.0.2.src
-          #- clang-version: 16
-            #release: llvm-project-16.0.3.src
-          #- clang-version: 17
-            #release: llvm-project-17.0.6.src
+          - clang-version: 3.9
+            release: llvm-project-3.9.1
+          - clang-version: 4
+            release: llvm-project-4.0.1
+          - clang-version: 5
+            release: llvm-project-5.0.2
+          - clang-version: 6
+            release: llvm-project-6.0.1
+          - clang-version: 7
+            release: llvm-project-7.1.0
+          - clang-version: 8
+            release: llvm-project-8.0.1
+            extra-cmake-args: '-DCLANG_ANALYZER_ENABLE_Z3_SOLVER=OFF'
+          - clang-version: 9
+            release: llvm-project-9.0.1
+            extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
+          - clang-version: 10
+            release: llvm-project-10.0.1
+            extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
+          - clang-version: 11
+            release: llvm-project-11.1.0.src
+          - clang-version: 12
+            release: llvm-project-12.0.0.src
+          - clang-version: 12.0.1
+            release: llvm-project-12.0.1.src
+          - clang-version: 13
+            release: llvm-project-13.0.0.src
+          - clang-version: 14
+            release: llvm-project-14.0.0.src
+          - clang-version: 15
+            release: llvm-project-15.0.2.src
+          - clang-version: 16
+            release: llvm-project-16.0.3.src
+          - clang-version: 17
+            release: llvm-project-17.0.6.src
           - clang-version: 18
             release: llvm-project-18.1.8.src
           - clang-version: 19

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -8,44 +8,45 @@ jobs:
   build:
     strategy:
       matrix:
-        clang-version: [ 3.9, 4, 5, 6, 7, 8, 9, 10, 11, 12, 12.0.1, 13, 14, 15, 16, 17, 18, 19, 20 ]
+        #clang-version: [ 3.9, 4, 5, 6, 7, 8, 9, 10, 11, 12, 12.0.1, 13, 14, 15, 16, 17, 18, 19, 20 ]
+        clang-version: [ 18, 19, 20 ]
         os: [ linux, macosx, windows ]
         include:
-          - clang-version: 3.9
-            release: llvm-project-3.9.1
-          - clang-version: 4
-            release: llvm-project-4.0.1
-          - clang-version: 5
-            release: llvm-project-5.0.2
-          - clang-version: 6
-            release: llvm-project-6.0.1
-          - clang-version: 7
-            release: llvm-project-7.1.0
-          - clang-version: 8
-            release: llvm-project-8.0.1
-            extra-cmake-args: '-DCLANG_ANALYZER_ENABLE_Z3_SOLVER=OFF'
-          - clang-version: 9
-            release: llvm-project-9.0.1
-            extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
-          - clang-version: 10
-            release: llvm-project-10.0.1
-            extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
-          - clang-version: 11
-            release: llvm-project-11.1.0.src
-          - clang-version: 12
-            release: llvm-project-12.0.0.src
-          - clang-version: 12.0.1
-            release: llvm-project-12.0.1.src
-          - clang-version: 13
-            release: llvm-project-13.0.0.src
-          - clang-version: 14
-            release: llvm-project-14.0.0.src
-          - clang-version: 15
-            release: llvm-project-15.0.2.src
-          - clang-version: 16
-            release: llvm-project-16.0.3.src
-          - clang-version: 17
-            release: llvm-project-17.0.6.src
+          #- clang-version: 3.9
+            #release: llvm-project-3.9.1
+          #- clang-version: 4
+            #release: llvm-project-4.0.1
+          #- clang-version: 5
+            #release: llvm-project-5.0.2
+          #- clang-version: 6
+            #release: llvm-project-6.0.1
+          #- clang-version: 7
+            #release: llvm-project-7.1.0
+          #- clang-version: 8
+            #release: llvm-project-8.0.1
+            #extra-cmake-args: '-DCLANG_ANALYZER_ENABLE_Z3_SOLVER=OFF'
+          #- clang-version: 9
+            #release: llvm-project-9.0.1
+            #extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
+          #- clang-version: 10
+            #release: llvm-project-10.0.1
+            #extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
+          #- clang-version: 11
+            #release: llvm-project-11.1.0.src
+          #- clang-version: 12
+            #release: llvm-project-12.0.0.src
+          #- clang-version: 12.0.1
+            #release: llvm-project-12.0.1.src
+          #- clang-version: 13
+            #release: llvm-project-13.0.0.src
+          #- clang-version: 14
+            #release: llvm-project-14.0.0.src
+          #- clang-version: 15
+            #release: llvm-project-15.0.2.src
+          #- clang-version: 16
+            #release: llvm-project-16.0.3.src
+          #- clang-version: 17
+            #release: llvm-project-17.0.6.src
           - clang-version: 18
             release: llvm-project-18.1.8.src
           - clang-version: 19
@@ -60,7 +61,7 @@ jobs:
             dotexe: ''
             shacmd: 'sha512sum'
           - os: macosx
-            runner: macos-14
+            runner: macos-13
             os-cmake-args: '-DCMAKE_CXX_FLAGS="-static-libgcc -static-libstdc++ -flto" -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 ${POSIX_CMAKE_ARGS} ${MACOS_CMAKE_ARGS} -DLLVM_TARGETS_TO_BUILD=X86'
             build-args: '-j$(sysctl -n hw.ncpu)'
             bindir: '/build/bin'

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -61,7 +61,7 @@ jobs:
             dotexe: ''
             shacmd: 'sha512sum'
           - os: macosx
-            runner: macos-14
+            runner: macos-14-large # macos x86 runner
             os-cmake-args: '-DCMAKE_CXX_FLAGS="-static-libgcc -static-libstdc++ -flto" -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 ${POSIX_CMAKE_ARGS} ${MACOS_CMAKE_ARGS} -DLLVM_TARGETS_TO_BUILD=X86'
             build-args: '-j$(sysctl -n hw.ncpu)'
             bindir: '/build/bin'

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -61,7 +61,7 @@ jobs:
             dotexe: ''
             shacmd: 'sha512sum'
           - os: macosx
-            runner: macos-14-large # macos x86 runner
+            runner: macos-14
             os-cmake-args: '-DCMAKE_CXX_FLAGS="-static-libgcc -static-libstdc++ -flto" -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 ${POSIX_CMAKE_ARGS} ${MACOS_CMAKE_ARGS} -DLLVM_TARGETS_TO_BUILD=X86'
             build-args: '-j$(sysctl -n hw.ncpu)'
             bindir: '/build/bin'

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         #clang-version: [ 3.9, 4, 5, 6, 7, 8, 9, 10, 11, 12, 12.0.1, 13, 14, 15, 16, 17, 18, 19, 20 ]
-        clang-version: [ 17, 18, 19, 20 ]
+        clang-version: [ 18, 19, 20 ]
         os: [ linux, macosx, windows ]
         include:
           #- clang-version: 3.9
@@ -45,8 +45,8 @@ jobs:
             #release: llvm-project-15.0.2.src
           #- clang-version: 16
             #release: llvm-project-16.0.3.src
-          - clang-version: 17
-            release: llvm-project-17.0.6.src
+          #- clang-version: 17
+            #release: llvm-project-17.0.6.src
           - clang-version: 18
             release: llvm-project-18.1.8.src
           - clang-version: 19

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -86,7 +86,7 @@ jobs:
       suffix: '${{ matrix.clang-version }}_${{ matrix.os }}-amd64'
     steps:
     - name: Update homebrew
-      if: ${{ matrix.os == 'macosx' && matrix.clang-version >= '18' }}
+      if: ${{ matrix.os == 'macosx' && matrix.clang-version >= '17' }}
       shell: bash
       run: |
         brew update

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -8,42 +8,43 @@ jobs:
   build:
     strategy:
       matrix:
-        clang-version: [ 3.9, 4, 5, 6, 7, 8, 9, 10, 11, 12, 12.0.1, 13, 14, 15, 16, 17, 18, 19, 20 ]
+        #clang-version: [ 3.9, 4, 5, 6, 7, 8, 9, 10, 11, 12, 12.0.1, 13, 14, 15, 16, 17, 18, 19, 20 ]
+        clang-version: [ 17, 18, 19, 20 ]
         os: [ linux, macosx, windows ]
         include:
-          - clang-version: 3.9
-            release: llvm-project-3.9.1
-          - clang-version: 4
-            release: llvm-project-4.0.1
-          - clang-version: 5
-            release: llvm-project-5.0.2
-          - clang-version: 6
-            release: llvm-project-6.0.1
-          - clang-version: 7
-            release: llvm-project-7.1.0
-          - clang-version: 8
-            release: llvm-project-8.0.1
-            extra-cmake-args: '-DCLANG_ANALYZER_ENABLE_Z3_SOLVER=OFF'
-          - clang-version: 9
-            release: llvm-project-9.0.1
-            extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
-          - clang-version: 10
-            release: llvm-project-10.0.1
-            extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
-          - clang-version: 11
-            release: llvm-project-11.1.0.src
-          - clang-version: 12
-            release: llvm-project-12.0.0.src
-          - clang-version: 12.0.1
-            release: llvm-project-12.0.1.src
-          - clang-version: 13
-            release: llvm-project-13.0.0.src
-          - clang-version: 14
-            release: llvm-project-14.0.0.src
-          - clang-version: 15
-            release: llvm-project-15.0.2.src
-          - clang-version: 16
-            release: llvm-project-16.0.3.src
+          #- clang-version: 3.9
+            #release: llvm-project-3.9.1
+          #- clang-version: 4
+            #release: llvm-project-4.0.1
+          #- clang-version: 5
+            #release: llvm-project-5.0.2
+          #- clang-version: 6
+            #release: llvm-project-6.0.1
+          #- clang-version: 7
+            #release: llvm-project-7.1.0
+          #- clang-version: 8
+            #release: llvm-project-8.0.1
+            #extra-cmake-args: '-DCLANG_ANALYZER_ENABLE_Z3_SOLVER=OFF'
+          #- clang-version: 9
+            #release: llvm-project-9.0.1
+            #extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
+          #- clang-version: 10
+            #release: llvm-project-10.0.1
+            #extra-cmake-args: '-DLLVM_ENABLE_Z3_SOLVER=OFF'
+          #- clang-version: 11
+            #release: llvm-project-11.1.0.src
+          #- clang-version: 12
+            #release: llvm-project-12.0.0.src
+          #- clang-version: 12.0.1
+            #release: llvm-project-12.0.1.src
+          #- clang-version: 13
+            #release: llvm-project-13.0.0.src
+          #- clang-version: 14
+            #release: llvm-project-14.0.0.src
+          #- clang-version: 15
+            #release: llvm-project-15.0.2.src
+          #- clang-version: 16
+            #release: llvm-project-16.0.3.src
           - clang-version: 17
             release: llvm-project-17.0.4.src
             extra-cmake-args: '-DCMAKE_CXX_STANDARD=20'

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -79,7 +79,7 @@ jobs:
     env:
       COMMON_CMAKE_ARGS: '-DBUILD_SHARED_LIBS=OFF -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra"'
       LINUX_CMAKE_ARGS: '-DCMAKE_CXX_COMPILER=g++-10 -DCMAKE_C_COMPILER=gcc-10'
-      MACOS_CMAKE_ARGS: '-DCMAKE_CXX_COMPILER=g++-14 -DCMAKE_C_COMPILER=gcc-14'
+      MACOS_CMAKE_ARGS: '-DCMAKE_CXX_COMPILER=g++-14 -DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_STANDARD=17'
       POSIX_CMAKE_ARGS: '-DCMAKE_BUILD_TYPE=MinSizeRel'
       RELEASE: '${{ matrix.release }}'
       suffix: '${{ matrix.clang-version }}_${{ matrix.os }}-amd64'

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -47,16 +47,12 @@ jobs:
             #release: llvm-project-16.0.3.src
           - clang-version: 17
             release: llvm-project-17.0.4.src
-            extra-cmake-args: '-DCMAKE_CXX_STANDARD=20'
           - clang-version: 18
             release: llvm-project-18.1.8.src
-            extra-cmake-args: '-DCMAKE_CXX_STANDARD=20'
           - clang-version: 19
             release: llvm-project-19.1.0.src
-            extra-cmake-args: '-DCMAKE_CXX_STANDARD=20'
           - clang-version: 20
             release: llvm-project-20.1.0.src
-            extra-cmake-args: '-DCMAKE_CXX_STANDARD=20'
           - os: linux
             runner: ubuntu-22.04
             os-cmake-args: '-DLLVM_BUILD_STATIC=ON -DCMAKE_CXX_FLAGS="-s -flto" ${POSIX_CMAKE_ARGS} ${LINUX_CMAKE_ARGS}'
@@ -89,6 +85,13 @@ jobs:
       RELEASE: '${{ matrix.release }}'
       suffix: '${{ matrix.clang-version }}_${{ matrix.os }}-amd64'
     steps:
+    - name: Update homebrew
+      if: ${{ matrix.os == 'macosx' && matrix.clang-version >= '18' }}
+      shell: bash
+      run: |
+        brew update
+        brew upgrade
+        brew cleanup
     - name: download patches
       # we download a tarball of this repo, as the presence of a .git directory leaks
       # the commit hash of this repository into the clang binaries

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -148,10 +148,18 @@ jobs:
       if: ${{ ( matrix.clang-version == 9 || matrix.clang-version == 10 ) && matrix.os == 'windows' }}
       shell: bash
       run: patch ${{ matrix.release }}/llvm/cmake/config-ix.cmake windows-clang-9-10-trivially-copyable-mismatch.patch
-    - name: patch cmake implicit link libraries on macosx
+    - name: Patch cmake implicit link libraries on macosx
       if: ${{ matrix.os == 'macosx' }}
       shell: bash
-      run: sed -i.backup 's/gcc_eh.\*|/gcc_eh.*|gcc_ext.*|/g' $(find /usr/local/Cellar -name CMakeParseImplicitLinkInfo.cmake)
+      run: |
+        BREW_PREFIX=$(brew --prefix)
+        FILES=$(find "$BREW_PREFIX" -name CMakeParseImplicitLinkInfo.cmake)
+        
+        for file in $FILES; do
+          echo "Patching $file"
+          sed -i.backup 's/gcc_eh.*|/gcc_eh.*|gcc_ext.*|/g' "$file"
+        done
+
     - name: cmake
       run: cmake -S ${{ matrix.release }}/llvm -B ${{ matrix.release }}/build ${{ env.COMMON_CMAKE_ARGS }} ${{ matrix.os-cmake-args }} ${{ matrix.extra-cmake-args }}
     - name: build


### PR DESCRIPTION
# What
macos builds are running

# How
explicitly indicate x86
uses `brew --prefix` instead of hard-coded homebrew path