### PR TITLE
Easy MacOS arm fixes

### DIFF
--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -91,9 +91,6 @@ jobs:
             extra-tar-args-cfe: '--exclude=cfe-${version}.src/test/Driver/Inputs/*'
             arch: 'amd64'
         exclude:
-          # Clang 9 is not building on arm
-          - clang-version: 9
-            os: macos-arm
           # Clang 17 does not build on mac arm
           # See: https://github.com/llvm/llvm-project/pull/78704
           # https://github.com/llvm/llvm-project/issues/106521

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -102,6 +102,8 @@ jobs:
           #   tried: '/usr/lib/libz.1.dylib' (no such file)
           - clang-version: 19
             os: macos-arm
+          - clang-version: 20
+            os: macos-arm
     runs-on: ${{ matrix.runner }}
     env:
       COMMON_CMAKE_ARGS: '-DBUILD_SHARED_LIBS=OFF -DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra"'

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -45,7 +45,7 @@ jobs:
           - clang-version: 16
             release: llvm-project-16.0.3.src
           - clang-version: 17
-            release: llhttps://github.com/llvm/llvm-project/pull/78704vm-project-17.0.4.src
+            release: llvm-project-17.0.4.src
           - clang-version: 18
             release: llvm-project-18.1.8.src
           - clang-version: 19

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -94,9 +94,6 @@ jobs:
           # Clang 9 is not building on arm
           - clang-version: 9
             os: macos-arm
-          # Clang 14 is not building on arm
-          - clang-version: 14
-            os: macos-arm
           # Clang 17 does not build on mac arm
           # See: https://github.com/llvm/llvm-project/pull/78704
           # https://github.com/llvm/llvm-project/issues/106521

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -45,7 +45,7 @@ jobs:
           - clang-version: 16
             release: llvm-project-16.0.3.src
           - clang-version: 17
-            release: llvm-project-17.0.4.src
+            release: llhttps://github.com/llvm/llvm-project/pull/78704vm-project-17.0.4.src
           - clang-version: 18
             release: llvm-project-18.1.8.src
           - clang-version: 19
@@ -107,8 +107,6 @@ jobs:
           #   `Library not loaded: /usr/lib/libz.1.dylib`
           #   tried: '/usr/lib/libz.1.dylib' (no such file)
           - clang-version: 19
-            os: macos-arm
-          - clang-version: 20
             os: macos-arm
     runs-on: ${{ matrix.runner }}
     env:

--- a/.github/workflows/clang-tools-amd64.yml
+++ b/.github/workflows/clang-tools-amd64.yml
@@ -2,7 +2,7 @@ name: clang-tools-static-amd64
 
 on:
   push:
-    branches: [ master, macos-arm-squash ]
+    branches: [ master, macos-arm-fixes ]
 
 jobs:
   build:


### PR DESCRIPTION
Fixes issues with macOS arm builds that were broken during the first pass of this work.

These seem to be working now

Remaining issues are noted here: https://github.com/muttleyxd/clang-tools-static-binaries/issues?q=is%3Aissue%20state%3Aopen%20macOS%20arm

Fixes #79 